### PR TITLE
Refactor so that Memory context is built by the MemoryTool

### DIFF
--- a/Heat/Conversations/ConversationInput.swift
+++ b/Heat/Conversations/ConversationInput.swift
@@ -11,8 +11,6 @@ struct ConversationInput: View {
     @Environment(ConversationViewModel.self) var conversationViewModel
     @Environment(\.modelContext) private var modelContext
     
-    @Query(sort: \Memory.created, order: .forward) var memories: [Memory]
-    
     @State var imagePickerViewModel: ImagePickerViewModel
     @State var content: String
     @State var command: String
@@ -184,7 +182,7 @@ struct ConversationInput: View {
         guard !content.isEmpty else { return }
         
         do {
-            try conversationViewModel.generate(content, context: memories.map { $0.content })
+            try conversationViewModel.generate(content)
         } catch let error as KitError {
             conversationViewModel.error = error
         } catch {

--- a/Heat/Conversations/ConversationViewModel.swift
+++ b/Heat/Conversations/ConversationViewModel.swift
@@ -43,7 +43,7 @@ final class ConversationViewModel {
         conversationID = conversation.id
     }
     
-    func generate(_ content: String, context: [String] = []) throws {
+    func generate(_ content: String) throws {
         guard !content.isEmpty else { return }
         guard let conversation else {
             throw KitError.missingConversation
@@ -54,13 +54,12 @@ final class ConversationViewModel {
         
         let toolService = try store.preferredToolService()
         let toolModel = try store.preferredToolModel()
-        
-        let context = prepareContext(context)
-        
+        let contextTools: [ContextTool.Type] = [MemoryTool.self]
+
         generateTask = Task {
             await MessageManager()
                 .append(messages: messages)
-                .append(message: context)
+                .append(messages: contextTools.compactMap({ $0.prepareContext() }))
                 .append(message: .init(role: .user, content: content)) { message in
                     self.store.upsert(suggestions: [], conversationID: conversation.id)
                     self.store.upsert(message: message, conversationID: conversation.id)
@@ -252,16 +251,6 @@ final class ConversationViewModel {
             print(error)
         }
         return nil
-    }
-    
-    private func prepareContext(_ context: [String]) -> Message? {
-        guard !context.isEmpty else { return nil }
-        
-        return Message(role: .system, content: """
-            Some things to remember about who the user is. Use these to better relate to the user when responding:
-            
-            \(context.joined(separator: "\n"))
-            """)
     }
 }
 

--- a/Heat/Launcher/LauncherViewModel.swift
+++ b/Heat/Launcher/LauncherViewModel.swift
@@ -35,7 +35,7 @@ final class LauncherViewModel {
         conversationID = conversation.id
     }
     
-    func generate(_ content: String, context: [String] = []) throws {
+    func generate(_ content: String) throws {
         guard !content.isEmpty else { return }
         guard let conversation else {
             throw KitError.missingConversation
@@ -43,13 +43,12 @@ final class LauncherViewModel {
         
         let chatService = try store.preferredChatService()
         let chatModel = try store.preferredChatModel()
-        
-        let context = prepareContext(context)
+        let contextTools: [ContextTool.Type] = [MemoryTool.self]
         
         generateTask = Task {
             await MessageManager()
                 .append(messages: messages)
-                .append(message: context)
+                .append(messages: contextTools.compactMap({ $0.prepareContext() }))
                 .append(message: .init(role: .user, content: content)) { message in
                     self.store.upsert(suggestions: [], conversationID: conversation.id)
                     self.store.upsert(message: message, conversationID: conversation.id)

--- a/HeatKit/Sources/HeatKit/Tools/ContextTool.swift
+++ b/HeatKit/Sources/HeatKit/Tools/ContextTool.swift
@@ -1,0 +1,5 @@
+import GenKit
+
+public protocol ContextTool {
+    static func prepareContext() -> Message?
+}

--- a/HeatKit/Sources/HeatKit/Tools/MemoryTool.swift
+++ b/HeatKit/Sources/HeatKit/Tools/MemoryTool.swift
@@ -70,3 +70,23 @@ extension MemoryTool {
         }
     }
 }
+
+extension MemoryTool: ContextTool {
+    public static func prepareContext() -> Message? {
+        guard let container = try? ModelContainer(for: Memory.self) else { return nil }
+        let fetchRequest = FetchDescriptor<Memory>(sortBy: [SortDescriptor(\Memory.created, order: .forward)])
+        let context = ModelContext(container)
+        do {
+            let memories: [Memory] = try context.fetch(fetchRequest)
+            guard !memories.isEmpty else { return nil }
+            return Message(role: .system, content: """
+                Some things to remember about who the user is. Use these to better relate to the user when responding:
+
+                \(memories.map({ $0.content }).joined(separator: "\n"))
+                """)
+        } catch {
+            print("Failed to fetch memories: \(error)")
+            return nil
+        }
+    }
+}


### PR DESCRIPTION
I'm really enjoying digging into this code, I'd love to use it to build bots with custom Tools.

This opens the ability for other tools to also add context to the request. For instance, a FileTool could show the file tree of a directory, or a Reminders tool could include a particular list in the context, etc.